### PR TITLE
Add --copy-unstaged flag to copy unstaged changes to new worktrees

### DIFF
--- a/cmd/go-worktree/main.go
+++ b/cmd/go-worktree/main.go
@@ -78,15 +78,21 @@ func main() {
 func printUsage() {
 	fmt.Println("Golang Git Worktree Manager - Streamlined workflow")
 	fmt.Println("\nUsage:")
-	fmt.Println("  go-worktree create|add TICKET-ID [BASE-BRANCH]  Create a new worktree (default: main)")
+	fmt.Println("  go-worktree create|add TICKET-ID [BASE-BRANCH] [-u|--copy-unstaged]")
+	fmt.Println("                                                  Create a new worktree (default: main)")
 	fmt.Println("  go-worktree delete|rm TICKET-ID [-d]            Delete a worktree (-d to delete branch)")
 	fmt.Println("  go-worktree list|ls                             List all your worktrees")
 	fmt.Println("  go-worktree cd|switch TICKET-ID                 Print command to change to worktree")
 	fmt.Println("  go-worktree help|--help                         Show this help message")
 	fmt.Println("  go-worktree version|--version                   Show version information")
+	fmt.Println("\nFlags:")
+	fmt.Println("  -u, --copy-unstaged                             Copy unstaged changes to new worktree")
+	fmt.Println("  -d                                              Delete branch along with worktree")
 	fmt.Println("\nExamples:")
 	fmt.Println("  go-worktree create ABC-746                      Create worktree for ticket ABC-746")
 	fmt.Println("  go-worktree create ABC-746 develop              Create from develop branch")
+	fmt.Println("  go-worktree create ABC-746 -u                   Create and copy unstaged changes")
+	fmt.Println("  go-worktree create ABC-746 --copy-unstaged      Create and copy unstaged changes")
 	fmt.Println("  go-worktree delete ABC-746 -d                   Delete worktree and branch")
 	fmt.Println("  eval $(go-worktree cd ABC-746)                  Switch to ABC-746 worktree")
 }
@@ -95,6 +101,8 @@ func printUsage() {
 func handleCreate() {
 	createCommand := flag.NewFlagSet(cmdCreate, flag.ExitOnError)
 	baseBranch := createCommand.String("base", "main", "Base branch to create from")
+	copyUnstaged := createCommand.Bool("copy-unstaged", false, "Copy unstaged changes to the new worktree")
+	copyUnstagedShort := createCommand.Bool("u", false, "Copy unstaged changes to the new worktree (shorthand)")
 
 	// Parse remaining args
 	err := createCommand.Parse(os.Args[2:])
@@ -115,8 +123,11 @@ func handleCreate() {
 		*baseBranch = args[1]
 	}
 
+	// Combine both flag variants
+	shouldCopyUnstaged := *copyUnstaged || *copyUnstagedShort
+
 	wt := worktree.NewManager()
-	if err := wt.Create(ticket, *baseBranch); err != nil {
+	if err := wt.Create(ticket, *baseBranch, shouldCopyUnstaged); err != nil {
 		fmt.Fprintf(os.Stderr, "%sError: %v%s\n", util.ColorRed, err, util.ColorReset)
 		os.Exit(1)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -102,45 +102,38 @@ func (c *Client) ListWorktrees() ([]Worktree, error) {
 	return worktrees, nil
 }
 
+// gitOutputLines runs a git command and returns non-empty output lines.
+func gitOutputLines(args ...string) ([]string, error) {
+	output, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines, nil
+}
+
 // GetUnstagedFiles returns a list of all unstaged files (modified tracked files and untracked files)
 func (c *Client) GetUnstagedFiles() ([]string, error) {
-	var allFiles []string
-
-	// Get modified tracked files that are not staged
-	cmd := exec.Command("git", "diff", "--name-only")
-	output, err := cmd.Output()
+	modified, err := gitOutputLines("diff", "--name-only")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get modified files: %w", err)
 	}
-	if len(output) > 0 {
-		modifiedFiles := strings.Split(strings.TrimSpace(string(output)), "\n")
-		for _, file := range modifiedFiles {
-			if file != "" {
-				allFiles = append(allFiles, file)
-			}
-		}
-	}
 
-	// Get untracked files
-	cmd = exec.Command("git", "ls-files", "--others", "--exclude-standard")
-	output, err = cmd.Output()
+	untracked, err := gitOutputLines("ls-files", "--others", "--exclude-standard")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get untracked files: %w", err)
 	}
-	if len(output) > 0 {
-		untrackedFiles := strings.Split(strings.TrimSpace(string(output)), "\n")
-		for _, file := range untrackedFiles {
-			if file != "" {
-				allFiles = append(allFiles, file)
-			}
-		}
-	}
 
-	return allFiles, nil
+	return append(modified, untracked...), nil
 }
 
-// GetCurrentWorkingDir returns the root directory of the current git repository
-func (c *Client) GetCurrentWorkingDir() (string, error) {
+// GetGitRepoRoot returns the root directory of the current git repository
+func (c *Client) GetGitRepoRoot() (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -101,3 +101,50 @@ func (c *Client) ListWorktrees() ([]Worktree, error) {
 
 	return worktrees, nil
 }
+
+// GetUnstagedFiles returns a list of all unstaged files (modified tracked files and untracked files)
+func (c *Client) GetUnstagedFiles() ([]string, error) {
+	var allFiles []string
+
+	// Get modified tracked files that are not staged
+	cmd := exec.Command("git", "diff", "--name-only")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get modified files: %w", err)
+	}
+	if len(output) > 0 {
+		modifiedFiles := strings.Split(strings.TrimSpace(string(output)), "\n")
+		for _, file := range modifiedFiles {
+			if file != "" {
+				allFiles = append(allFiles, file)
+			}
+		}
+	}
+
+	// Get untracked files
+	cmd = exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	output, err = cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get untracked files: %w", err)
+	}
+	if len(output) > 0 {
+		untrackedFiles := strings.Split(strings.TrimSpace(string(output)), "\n")
+		for _, file := range untrackedFiles {
+			if file != "" {
+				allFiles = append(allFiles, file)
+			}
+		}
+	}
+
+	return allFiles, nil
+}
+
+// GetCurrentWorkingDir returns the root directory of the current git repository
+func (c *Client) GetCurrentWorkingDir() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -189,7 +189,7 @@ func (m *Manager) List() error {
 // copyUnstagedFiles copies unstaged files from the current working directory to the target worktree
 func (m *Manager) copyUnstagedFiles(targetPath string) error {
 	// Get the current working directory
-	sourceDir, err := m.git.GetCurrentWorkingDir()
+	sourceDir, err := m.git.GetGitRepoRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)
 	}
@@ -230,7 +230,7 @@ func (m *Manager) copyUnstagedFiles(targetPath string) error {
 }
 
 // copyFile copies a single file from src to dst
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (err error) {
 	sourceFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -241,7 +241,12 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer destFile.Close()
+	defer func() {
+		closeErr := destFile.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 
 	_, err = io.Copy(destFile, sourceFile)
 	if err != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -4,6 +4,7 @@ package worktree
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -51,7 +52,7 @@ func (m *Manager) GetPath(ticket string) (string, error) {
 }
 
 // Create creates a new git worktree
-func (m *Manager) Create(ticket, baseBranch string) error {
+func (m *Manager) Create(ticket, baseBranch string, copyUnstaged bool) error {
 	repo, err := m.git.GetRepoName()
 	if err != nil {
 		return err
@@ -79,6 +80,13 @@ func (m *Manager) Create(ticket, baseBranch string) error {
 	fmt.Printf("Creating worktree for %s%s%s...\n", util.ColorBlue, ticket, util.ColorReset)
 	if err := m.git.CreateWorktree(worktreeDir, ticket); err != nil {
 		return fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	// Copy unstaged files if requested
+	if copyUnstaged {
+		if err := m.copyUnstagedFiles(worktreeDir); err != nil {
+			return fmt.Errorf("failed to copy unstaged files: %w", err)
+		}
 	}
 
 	fmt.Printf("%sSuccess!%s Worktree created at: %s\n", util.ColorGreen, util.ColorReset, worktreeDir)
@@ -176,4 +184,74 @@ func (m *Manager) List() error {
 	}
 
 	return nil
+}
+
+// copyUnstagedFiles copies unstaged files from the current working directory to the target worktree
+func (m *Manager) copyUnstagedFiles(targetPath string) error {
+	// Get the current working directory
+	sourceDir, err := m.git.GetCurrentWorkingDir()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	// Get the list of unstaged files
+	unstagedFiles, err := m.git.GetUnstagedFiles()
+	if err != nil {
+		return fmt.Errorf("failed to get unstaged files: %w", err)
+	}
+
+	if len(unstagedFiles) == 0 {
+		fmt.Printf("No unstaged files to copy\n")
+		return nil
+	}
+
+	fmt.Printf("Copying %d unstaged file(s) to worktree...\n", len(unstagedFiles))
+
+	// Copy each unstaged file
+	for _, relPath := range unstagedFiles {
+		srcPath := filepath.Join(sourceDir, relPath)
+		dstPath := filepath.Join(targetPath, relPath)
+
+		// Create destination directory if needed
+		dstDir := filepath.Dir(dstPath)
+		if err := os.MkdirAll(dstDir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dstDir, err)
+		}
+
+		// Copy file
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return fmt.Errorf("failed to copy %s: %w", relPath, err)
+		}
+
+		fmt.Printf("  Copied: %s%s%s\n", util.ColorYellow, relPath, util.ColorReset)
+	}
+
+	return nil
+}
+
+// copyFile copies a single file from src to dst
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	if err != nil {
+		return err
+	}
+
+	// Copy file permissions
+	sourceInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, sourceInfo.Mode())
 }


### PR DESCRIPTION
This feature allows developers to copy unstaged changes (both modified tracked files and untracked files) from their current working directory into newly created worktrees. This is useful for files like CLAUDE.md or other development artifacts that are needed across worktrees but aren't tracked in git.

Changes:
- Add GetUnstagedFiles() and GetCurrentWorkingDir() methods to git.Client
- Add copyUnstagedFiles() helper to worktree.Manager
- Update Create() method to accept copyUnstaged parameter
- Add -u and --copy-unstaged flags to create command
- Update usage documentation with examples

Usage:
  go-worktree create TICKET-123 -u go-worktree create TICKET-123 --copy-unstaged